### PR TITLE
2.EDITED add employee prompt

### DIFF
--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -37,7 +37,7 @@ const prompts = [
   {
     type: "input",
     name: "add-employee",
-    message: "Please enter the employee's first name, last name, role, and manager (first name, last name, role, manager).",
+    message: "Please enter the employee's first name, last name, role, and manager (first name, last name, role id, manager id). If the employee does not have a manager, press enter after role id",
     when: (answers) => answers.menu === "Add a employee."
   },
   {


### PR DESCRIPTION
added an second line in add a employee prompt that let's them know to press enter after role id if the employee they want to add does not have a manager id associated with them so the value would be set to null by default